### PR TITLE
add logic which enables setting starting position at any place on the circle

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -8,7 +8,7 @@
       :side="300"
       :circleWidth="20"
       :knobRadius="20"
-      :stepSize="10"
+      :startPosition="300"
     >
     </circle-slider>
     <div class="value"> {{ sliderValue }} </div>


### PR DESCRIPTION
Logic was added which enables setting starting position at any place on the circle. Default position is 90 degrees, which is at the bottom of the circle. Prop called "startPosition" can be added with any value in degrees from 0 to 360, which moves the knob to a different starting position. 